### PR TITLE
Hotfix/remove

### DIFF
--- a/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBBase.java
+++ b/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBBase.java
@@ -181,7 +181,7 @@ public class NCMBBase {
         JSONObject json = new JSONObject();
         for (String key: mUpdateKeys) {
             if (mFields.isNull(key)){
-                json.put(key, null);
+                json.put(key, JSONObject.NULL);
             } else {
                 json.put(key, mFields.get(key));
             }

--- a/ncmb-core/src/test/java/com/nifty/cloud/mb/core/NCMBDispatcher.java
+++ b/ncmb-core/src/test/java/com/nifty/cloud/mb/core/NCMBDispatcher.java
@@ -1,6 +1,7 @@
 package com.nifty.cloud.mb.core;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.squareup.okhttp.mockwebserver.Dispatcher;
 import com.squareup.okhttp.mockwebserver.MockResponse;
 import com.squareup.okhttp.mockwebserver.RecordedRequest;
@@ -85,7 +86,8 @@ public class NCMBDispatcher {
                             requestBody = request.getBody().readString(request.getBodySize(), Charset.forName("UTF-8"));
                         }
                         Object mockBody = requestMap.get("body");
-                        String mockBodyStr = new Gson().toJson(mockBody);
+                        Gson gson = new GsonBuilder().serializeNulls().create();
+                        String mockBodyStr = gson.toJson(mockBody);
                         System.out.println("mock:" + mockBodyStr);
                         System.out.println("req:" + requestBody);
                         if (checkRequestBody(mockBodyStr, requestBody)) {


### PR DESCRIPTION
see #33 

removeメソッドで削除されたキーに対して、

```
{"fieldName":null}
```

のフォーマットでサーバー側の値も削除するように改修しました。

また、それをモックサーバーでテストできるように改修しました。