### PR TITLE
fix getDate method null check

### DIFF
--- a/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBBase.java
+++ b/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBBase.java
@@ -515,8 +515,10 @@ public class NCMBBase {
             // Date型変換
             if (mFields.has(key)){
                 JSONObject dateJson = this.getJSONObject(key);
-                if (dateJson.has("iso")){
-                    return sdf.parse(dateJson.getString("iso"));
+                if (dateJson != null) {
+                    if (dateJson.has("iso")) {
+                        return sdf.parse(dateJson.getString("iso"));
+                    }
                 }
             }
 

--- a/ncmb-core/src/test/java/com/nifty/cloud/mb/core/NCMBBaseTest.java
+++ b/ncmb-core/src/test/java/com/nifty/cloud/mb/core/NCMBBaseTest.java
@@ -501,5 +501,11 @@ public class NCMBBaseTest {
         Assert.assertTrue(baseObj.containsKey("key"));
     }
 
+    @Test
+    public void get_date_null_object() throws Exception {
+        NCMBBase obj = new NCMBBase("testClass", new JSONObject("{\"date\":null}"));
+        Assert.assertNull(obj.getDate("date"));
+    }
+
 
 }

--- a/ncmb-core/src/test/java/com/nifty/cloud/mb/core/NCMBConnectionTest.java
+++ b/ncmb-core/src/test/java/com/nifty/cloud/mb/core/NCMBConnectionTest.java
@@ -11,6 +11,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 
@@ -29,6 +30,12 @@ public class NCMBConnectionTest {
         mServer = new MockWebServer();
         mServer.setDispatcher(NCMBDispatcher.dispatcher);
         mServer.start();
+
+        NCMB.initialize(RuntimeEnvironment.application.getApplicationContext(),
+                "appKey",
+                "cliKey",
+                mServer.getUrl("/").toString(),
+                null);
     }
 
     @After
@@ -183,7 +190,7 @@ public class NCMBConnectionTest {
         }
 
         //ステータスコード200及びresponseDataが返却されるか確認
-        //Assert.assertNull(error);
+        Assert.assertNull(error);
         Assert.assertEquals(200, response.statusCode);
         Assert.assertNull(response.responseData);
 

--- a/ncmb-core/src/test/java/com/nifty/cloud/mb/core/NCMBConnectionTest.java
+++ b/ncmb-core/src/test/java/com/nifty/cloud/mb/core/NCMBConnectionTest.java
@@ -183,7 +183,7 @@ public class NCMBConnectionTest {
         }
 
         //ステータスコード200及びresponseDataが返却されるか確認
-        Assert.assertNull(error);
+        //Assert.assertNull(error);
         Assert.assertEquals(200, response.statusCode);
         Assert.assertNull(response.responseData);
 


### PR DESCRIPTION
## 概要(Summary)

- Fixed #100

## 動作確認手順(Step for Confirmation)

テストコードですが、以下のコードをNCMBBaseTest.javaに追加し、
ローカルで実行し確認いたしました。

    @Test
    public void get_date_non_object() throws Exception {
        NCMBBase obj = new NCMBBase("testClass", new JSONObject("{\"datenull\":null}"));
        Assert.assertNull(obj.getDate("datenull"));
    }

ローカルでは正常にテストできているのですが、コミットするとTravis CIでエラーが発生します。
（エラー内容はNCMBConnectionTestでのStackOverflowErrorとなっています）
テストコードをいろいろ試しましたが、NCMBBaseTestにコメントを追加するだけでも同上のエラーが発生してしまうため、直接コードを書かせていただきました。
お手数ですがご確認をお願いいたします。