### PR TITLE
プッシュ通知アイコンの色を変更

### DIFF
--- a/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBGcmListenerService.java
+++ b/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBGcmListenerService.java
@@ -28,6 +28,7 @@ public class NCMBGcmListenerService extends GcmListenerService {
     //<meta-data>
     static final String OPEN_PUSH_START_ACTIVITY_KEY = "openPushStartActivity";
     static final String SMALL_ICON_KEY = "smallIcon";
+    static final String SMALL_ICON_COLOR = "smallIconColor";
     static final String NOTIFICATION_OVERLAP_KEY = "notificationOverlap";
 
     @Override
@@ -158,6 +159,7 @@ public class NCMBGcmListenerService extends GcmListenerService {
         Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this)
                 .setSmallIcon(icon)//通知エリアのアイコン設定
+                .setColor(appInfo.metaData.getInt(SMALL_ICON_COLOR)) //通知エリアのアイコンカラー設定
                 .setContentTitle(title)
                 .setContentText(message)
                 .setAutoCancel(true)//通知をタップしたら自動で削除する

--- a/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBGcmListenerService.java
+++ b/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBGcmListenerService.java
@@ -28,7 +28,7 @@ public class NCMBGcmListenerService extends GcmListenerService {
     //<meta-data>
     static final String OPEN_PUSH_START_ACTIVITY_KEY = "openPushStartActivity";
     static final String SMALL_ICON_KEY = "smallIcon";
-    static final String SMALL_ICON_COLOR = "smallIconColor";
+    static final String SMALL_ICON_COLOR_KEY = "smallIconColor";
     static final String NOTIFICATION_OVERLAP_KEY = "notificationOverlap";
 
     @Override
@@ -154,12 +154,14 @@ public class NCMBGcmListenerService extends GcmListenerService {
             //それ以外はアプリのアイコンを設定する
             icon = appInfo.icon;
         }
+        //SmallIconカラーを設定
+        int smallIconColor = appInfo.metaData.getInt(SMALL_ICON_COLOR_KEY);
 
         //Notification作成
         Uri defaultSoundUri = RingtoneManager.getDefaultUri(RingtoneManager.TYPE_NOTIFICATION);
         NotificationCompat.Builder notificationBuilder = new NotificationCompat.Builder(this)
                 .setSmallIcon(icon)//通知エリアのアイコン設定
-                .setColor(appInfo.metaData.getInt(SMALL_ICON_COLOR)) //通知エリアのアイコンカラー設定
+                .setColor(smallIconColor) //通知エリアのアイコンカラー設定
                 .setContentTitle(title)
                 .setContentText(message)
                 .setAutoCancel(true)//通知をタップしたら自動で削除する


### PR DESCRIPTION
 ## 概要(Summary)

 - Fixed #108

 ## 動作確認手順(Step for Confirmation)

```
 1.プッシュ通知アイコンカラー設定
 【app/manifests/AndroidManifest.xml】
   <!-- プッシュ通知Icon BackColorの設定-->
   <meta-data android:name="smallIconColor" android:value="@color/blue"/>

  2.カラー定義設定
  【app/res/values/colors.xml】
    <color name="blue">#4cb6ff</color>
```

 Run the 端末確認.