### PR TITLE
NCMBRoleServiceのsetAclメソッドの名前変更

### DIFF
--- a/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBRoleService.java
+++ b/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBRoleService.java
@@ -710,7 +710,7 @@ public class NCMBRoleService extends NCMBService {
     }
 
     /**
-     * Set ACL to role
+     * Update ACL to role
      *
      * @param roleId role id
      * @param acl    Assigned ACL
@@ -724,7 +724,7 @@ public class NCMBRoleService extends NCMBService {
     }
 
     /**
-     * Set ACL to role in background
+     * Update ACL to role in background
      *
      * @param roleId   role id
      * @param acl      Assigned ACL

--- a/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBRoleService.java
+++ b/ncmb-core/src/main/java/com/nifty/cloud/mb/core/NCMBRoleService.java
@@ -716,7 +716,7 @@ public class NCMBRoleService extends NCMBService {
      * @param acl    Assigned ACL
      * @throws NCMBException exception sdk internal or NIFTY Cloud mobile backend
      */
-    public void setAcl(String roleId, NCMBAcl acl) throws NCMBException {
+    public void updateAcl(String roleId, NCMBAcl acl) throws NCMBException {
         RequestParams reqParams = setAclParams(roleId, acl);
         NCMBResponse response = sendRequest(reqParams);
         setAclCheckResponse(response);
@@ -731,7 +731,7 @@ public class NCMBRoleService extends NCMBService {
      * @param callback callback when process finished
      * @throws NCMBException exception sdk internal or NIFTY Cloud mobile backend
      */
-    public void setAclInBackground(String roleId, NCMBAcl acl, DoneCallback callback) throws NCMBException {
+    public void updateAclInBackground(String roleId, NCMBAcl acl, DoneCallback callback) throws NCMBException {
         RequestParams reqParams = setAclParams(roleId, acl);
         sendRequestAsync(reqParams, new RoleServiceCallback(this, callback) {
             @Override

--- a/ncmb-core/src/test/java/com/nifty/cloud/mb/core/NCMBRoleServiceTest.java
+++ b/ncmb-core/src/test/java/com/nifty/cloud/mb/core/NCMBRoleServiceTest.java
@@ -443,7 +443,7 @@ public class NCMBRoleServiceTest {
      * - 結果：例外が発生しないこと
      */
     @Test
-    public void setAcl() throws Exception {
+    public void updateAcl() throws Exception {
         NCMBRoleService roleService = getRoleService();
         String roleId = "dummyRoleId";
 
@@ -460,7 +460,7 @@ public class NCMBRoleServiceTest {
      * - 結果：callback に例外が返らないこと
      */
     @Test
-    public void setAclInBackground() throws Exception {
+    public void updateAclInBackground() throws Exception {
         NCMBRoleService roleService = getRoleService();
         String roleId = "dummyRoleId";
 

--- a/ncmb-core/src/test/java/com/nifty/cloud/mb/core/NCMBRoleServiceTest.java
+++ b/ncmb-core/src/test/java/com/nifty/cloud/mb/core/NCMBRoleServiceTest.java
@@ -449,7 +449,7 @@ public class NCMBRoleServiceTest {
 
         try {
             NCMBAcl acl = generateAcl();
-            roleService.setAcl(roleId, acl);
+            roleService.updateAcl(roleId, acl);
         } catch (NCMBException e) {
             Assert.fail(e.getMessage());
         }
@@ -465,7 +465,7 @@ public class NCMBRoleServiceTest {
         String roleId = "dummyRoleId";
 
         NCMBAcl acl = generateAcl();
-        roleService.setAclInBackground(roleId, acl, new DoneCallback() {
+        roleService.updateAclInBackground(roleId, acl, new DoneCallback() {
             @Override
             public void done(NCMBException e) {
                 Assert.assertEquals(e, null);


### PR DESCRIPTION
- Fixed #115

 Step 1: Update method name setAcl/setAclInBackground to updateAcl/updateAclInBackground in file NCMBRoleService
 Step 2: Update method name setAcl/setAclInBackground to updateAcl/updateAclInBackground  in file NCMBRoleServiceTest

Run the unit test.
Run unit test file NCMBRoleServiceTest is success.

Run all unit test file and 2 file test error:
NCMBInstallationServiceTest with error message:

```
May 18, 2017 5:39:11 PM com.squareup.okhttp.mockwebserver.MockWebServer$3 processOneRequest
INFO: MockWebServer[60045] received request: PUT /2013-09-01/installations/7FrmPTBKSNtVjajm HTTP/1.1 and responded: HTTP/1.1 404 OK
May 18, 2017 5:39:11 PM com.squareup.okhttp.mockwebserver.MockWebServer$2 acceptConnections
INFO: MockWebServer[60045] done accepting connections: Socket closed

com.nifty.cloud.mb.core.NCMBException: None service.

	at com.nifty.cloud.mb.core.NCMBConnection.sendRequest(NCMBConnection.java:164)
	at com.nifty.cloud.mb.core.NCMBService.sendRequest(NCMBService.java:181)
	at com.nifty.cloud.mb.core.NCMBService.sendRequest(NCMBService.java:214)
	at com.nifty.cloud.mb.core.NCMBInstallationService.updateInstallation(NCMBInstallationService.java:187)
	at com.nifty.cloud.mb.core.NCMBInstallationServiceTest.currentInstallation_PUT(NCMBInstallationServiceTest.java:478)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.robolectric.RobolectricTestRunner$2.evaluate(RobolectricTestRunner.java:251)
	at org.robolectric.RobolectricTestRunner.runChild(RobolectricTestRunner.java:188)
	at org.robolectric.RobolectricTestRunner.runChild(RobolectricTestRunner.java:54)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.robolectric.RobolectricTestRunner$1.evaluate(RobolectricTestRunner.java:152)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:117)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:42)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:262)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:84)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
```
NCMBTest with error message:
```com.thoughtworks.xstream.converters.ConversionException: Cannot construct org.powermock.modules.junit4.rule.PowerMockStatement$1 as it does not have a no-args constructor : Cannot construct org.powermock.modules.junit4.rule.PowerMockStatement$1 as it does not have a no-args constructor
---- Debugging information ----
message             : Cannot construct org.powermock.modules.junit4.rule.PowerMockStatement$1 as it does not have a no-args constructor
cause-exception     : com.thoughtworks.xstream.converters.reflection.ObjectAccessException
cause-message       : Cannot construct org.powermock.modules.junit4.rule.PowerMockStatement$1 as it does not have a no-args constructor
class               : org.powermock.modules.junit4.rule.PowerMockStatement$1
required-type       : org.powermock.modules.junit4.rule.PowerMockStatement$1
converter-type      : com.thoughtworks.xstream.converters.reflection.ReflectionConverter
path                : /org.powermock.modules.junit4.rule.PowerMockStatement$1
line number         : 1
version             : null
-------------------------------

	at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:79)
	at com.thoughtworks.xstream.core.AbstractReferenceUnmarshaller.convert(AbstractReferenceUnmarshaller.java:65)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:66)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convertAnother(TreeUnmarshaller.java:50)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.start(TreeUnmarshaller.java:134)
	at com.thoughtworks.xstream.core.AbstractTreeMarshallingStrategy.unmarshal(AbstractTreeMarshallingStrategy.java:32)
	at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1052)
	at com.thoughtworks.xstream.XStream.unmarshal(XStream.java:1036)
	at com.thoughtworks.xstream.XStream.fromXML(XStream.java:912)
	at com.thoughtworks.xstream.XStream.fromXML(XStream.java:903)
	at org.powermock.classloading.DeepCloner.clone(DeepCloner.java:54)
	at org.powermock.classloading.ClassloaderExecutor.execute(ClassloaderExecutor.java:89)
	at org.powermock.classloading.ClassloaderExecutor.execute(ClassloaderExecutor.java:78)
	at org.powermock.modules.junit4.rule.PowerMockStatement.evaluate(PowerMockRule.java:49)
	at org.robolectric.RobolectricTestRunner$2.evaluate(RobolectricTestRunner.java:251)
	at org.robolectric.RobolectricTestRunner.runChild(RobolectricTestRunner.java:188)
	at org.robolectric.RobolectricTestRunner.runChild(RobolectricTestRunner.java:54)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.robolectric.RobolectricTestRunner$1.evaluate(RobolectricTestRunner.java:152)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runners.Suite.runChild(Suite.java:128)
	at org.junit.runners.Suite.runChild(Suite.java:27)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:117)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:42)
	at com.intellij.rt.execution.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:262)
	at com.intellij.rt.execution.junit.JUnitStarter.main(JUnitStarter.java:84)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
Caused by: com.thoughtworks.xstream.converters.reflection.ObjectAccessException: Cannot construct org.powermock.modules.junit4.rule.PowerMockStatement$1 as it does not have a no-args constructor
	at com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider.newInstance(PureJavaReflectionProvider.java:71)
	at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.instantiateNewInstance(AbstractReflectionConverter.java:428)
	at com.thoughtworks.xstream.converters.reflection.AbstractReflectionConverter.unmarshal(AbstractReflectionConverter.java:233)
	at com.thoughtworks.xstream.core.TreeUnmarshaller.convert(TreeUnmarshaller.java:72)
	... 41 more
```